### PR TITLE
Update domains for EqualWeb

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -13,7 +13,7 @@ const theNaughtyList: Record<string, string[]> = {
   AccessiBe: ["*://*.acsbap.com/*", "*://*.acsbapp.com/*"],
   UserWay: ["*://*.userway.org/*"],
   AudioEye: ["*://*.audioeye.com/*"],
-  EqualWeb: ["*://*.nagich.com/*", "*://*.nagich.co.il/*"],
+  EqualWeb: ["*://cdn.equalweb.com/*", "*://*.nagich.com/*", "*://*.nagich.co.il/*"],
   TruAbilities: ["*://*.truabilities.com/*"],
   MaxAccess: ["*://*.maxaccess.io/*"],
   User1st: ["*://*.user1st.info/*"],


### PR DESCRIPTION
This adds another domain encountered for the EqualWeb  vendor, as encountered on gsatcedders.org.